### PR TITLE
Add bot pinging functionality along with CLI support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,13 @@ setup:
 		$(POETRY) install --no-root --quiet; \
 	fi
 
-run: 
-	@$(POETRY) run python zulip-bot/bot.py
+# Run bot client script as one-off instance
+run-client:
+	@$(POETRY) run python zulip-bot/bot.py --client
+
+# Run bot server 24/7 to listen & respond 
+run-server:
+	@$(POETRY) run python zulip-bot/bot.py --server
 
 clean:
 	@echo "Removing virtual environment..."

--- a/poetry.lock
+++ b/poetry.lock
@@ -244,4 +244,4 @@ typing-extensions = ">=4.5.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "b1b2dcc1605fbf4baaa370dfe1a7c709029ea9b82557f1353747ad0199743b3a"
+content-hash = "146e2b9e5aa6493aa5c06badcfc53bdffa4bea9adf5d71b9e0e759defbe948d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ python = ">=3.10,<3.14"
 requests = "^2.31.0"
 python-dotenv = "^1.0.0"
 zulip = "^0.9.0"
+click = "^8.3.0"
 
 
 [build-system]

--- a/zulip-bot/bot.py
+++ b/zulip-bot/bot.py
@@ -5,7 +5,8 @@
 ###############################################################################
 
 
-from src.setup import create_client
+from src.setup import create_client, subscribe_to_all_public_streams
+from src.bridge import process_request
 from src.notifier import send_notification
 
 
@@ -13,14 +14,23 @@ class CouchesBridgeBot:
     def __init__(self):
         self.client = create_client()
 
-        # bot receives trigger
-        # bot sends notification
+        self.subscribed_streams = subscribe_to_all_public_streams(self.client)
+
+    def run(self):
+        self.client.call_on_each_event(
+            lambda msg_event: process_request(msg_event, self.client), 
+            event_types=["message"]
+        )
+
+    # bot receives trigger
+    # bot sends notification
 
 
 if __name__ == "__main__":
     bot = CouchesBridgeBot()
+    bot.run()
 
-    send_notification(bot.client)
+    # send_notification(bot.client)
     
 
 

--- a/zulip-bot/bot.py
+++ b/zulip-bot/bot.py
@@ -5,9 +5,11 @@
 ###############################################################################
 
 
+import click # for args via CLI 
+
 from src.setup import create_client, subscribe_to_all_public_streams
 from src.bridge import process_request
-from src.notifier import send_notification
+from src.notifier import send_announcement
 
 
 class CouchesBridgeBot:
@@ -22,15 +24,44 @@ class CouchesBridgeBot:
             event_types=["message"]
         )
 
-    # bot receives trigger
-    # bot sends notification
+
+# Instantiate bot just once as a global so Click can access it 
+bot = CouchesBridgeBot()
+
+
+@click.command()
+@click.option('--client', is_flag=True, help="Run in client mode")
+@click.option('--server', is_flag=True, help="Run in server mode")
+def launch_program(client, server):
+    if client and server:
+        click.echo("ERROR: You can't use --client and --server together")
+
+    # Bot acts as a one-off script to send announcement for bridge opening
+    elif client:
+        click.echo("Running in client mode...")
+        send_announcement(bot.client)
+
+    # Bot acts as a server running 24/7 to listen for & respond to messages
+    elif server:
+        click.echo("Running in server mode...")
+        bot.run()
+
+    else:
+        click.echo("ERROR: Please specify --client or --server")
 
 
 if __name__ == "__main__":
-    bot = CouchesBridgeBot()
-    bot.run()
+    # NOTES from 10/2/25 meeting:
+    #   here within main, have CLI flags to pass to run script that allow you to
+    #   either use it as the 24/7 bot OR otherwise as a one-off script to run..
+    #   can use Python Click to pass CLI arguments
+    # For example,
+    #   `python3 bot.py --client`
+    #   `python3 bot.py --server`
+    # Or alternativey, just use Makefile rules
+    #   `make run-client`
+    #   `make run-server`
 
-    # send_notification(bot.client)
-    
+    launch_program()
 
 

--- a/zulip-bot/src/bridge.py
+++ b/zulip-bot/src/bridge.py
@@ -5,6 +5,9 @@
 ###############################################################################
 
 
+from src.notifier import send_request_succeeded, send_request_failed
+
+
 def process_request(msg_event, client):
     if msg_event["type"] != "message":
         return
@@ -27,5 +30,29 @@ def process_request(msg_event, client):
 
         print(msg_event)
         print(msg["content"])
+
+        parse_message(msg, client)
+
+
+def parse_message(msg, client):
+    VALID_PROMPTS = [
+        "open the portal",
+        "open the couch portal",
+        "open the bridge",
+        "open the couch bridge"
+    ]
+
+    # Tag person who requested bridge to notify them of result
+    user_to_mention = msg["sender_full_name"]
+    mention_markdown = f"@**{user_to_mention}**"
+
+    curr_stream_id, curr_subject = msg["stream_id"], msg["subject"]
+
+    content = msg["content"].lower()
+
+    if not any(prompt in content for prompt in VALID_PROMPTS):
+        send_request_failed(mention_markdown, curr_stream_id, curr_subject, client)
+    else:
+        send_request_succeeded(mention_markdown, curr_stream_id, curr_subject, client)
 
 

--- a/zulip-bot/src/bridge.py
+++ b/zulip-bot/src/bridge.py
@@ -1,0 +1,31 @@
+###############################################################################
+##  `bridge.py`                                                              ##
+##                                                                           ##
+##  Purpose: Processes request pipeline to open couches bridge               ##
+###############################################################################
+
+
+def process_request(msg_event, client):
+    if msg_event["type"] != "message":
+        return
+    
+    msg = msg_event["message"]
+    
+    # Determine message type (DM vs mention in channel)
+    is_dm = msg["type"] == "private"
+    is_mention = "mentioned" in msg_event.get("flags", [])
+
+    if is_dm:
+        print("message is DM!")
+
+        print(msg_event)
+        print(msg["content"])
+
+
+    elif is_mention:
+        print("message is mention!")
+
+        print(msg_event)
+        print(msg["content"])
+
+

--- a/zulip-bot/src/notifier.py
+++ b/zulip-bot/src/notifier.py
@@ -5,19 +5,19 @@
 ###############################################################################
 
 
-# NOTICE_STREAM_ID = "🧑‍💻 current batches" # channel (e.g. checkins)
-# NOTICE_SUBJECT = "Virtual couches co-working" # topic (e.g. FirstName LastName)
+NOTICE_STREAM_ID = "🧑‍💻 current batches" # channel (e.g. checkins)
+NOTICE_SUBJECT = "Virtual couches co-working" # topic (e.g. FirstName LastName)
 
-# HUB_STREAM_ID = "397 Bridge"
-# HUB_SUBJECT = "RCTV Couches Telepresence"
+HUB_STREAM_ID = "397 Bridge"
+HUB_SUBJECT = "RCTV Couches Telepresence"
 
 
 # TESTING FOR NOW
-NOTICE_STREAM_ID = "test-bot" 
-NOTICE_SUBJECT = "RC-couches-telepresence-bridge" 
+# NOTICE_STREAM_ID = "test-bot" 
+# NOTICE_SUBJECT = "RC-couches-telepresence-bridge" 
 
-HUB_STREAM_ID = "test-bot"
-HUB_SUBJECT = "RC-couches-telepresence-bridge"
+# HUB_STREAM_ID = "test-bot"
+# HUB_SUBJECT = "RC-couches-telepresence-bridge"
 
 
 ZOOM_LINK = "https://www.recurse.com/zoom/couches"
@@ -39,7 +39,7 @@ def send_request_succeeded(mention_markdown, curr_stream_id, curr_subject, clien
     hub_request_link = f"#**{HUB_STREAM_ID}>{HUB_SUBJECT}** "
 
     REQUEST_SUCCEEDED = (
-        f"{mention_markdown} Great! Thanks for pinging me. "
+        f"{mention_markdown} Hey there! Thanks for pinging me. "
         f"I'll send a request to folks at the hub over in {hub_request_link}"
     )
 
@@ -47,11 +47,15 @@ def send_request_succeeded(mention_markdown, curr_stream_id, curr_subject, clien
 
     # Prepare request to in-person hub folks (397 Bridge channel)
     mention_topic = "@**topic**"
+    testing_spot = "#**test-bot>RC-couches-telepresence-bridge**"
     
     REQUEST_TO_HUB = (
         f"{mention_topic} Hey hub folks! "
         "The remote RCers would like to open the couches bridge for telepresence. "
         "Can you help them out? Activate the Zoom call on RCTV!"
+
+        "\n\nI'm a new bot being tested in production. Feel free to say hello to me! "
+        f"For more info, visit {testing_spot}"
     )
 
     send_notification(REQUEST_TO_HUB, HUB_STREAM_ID, HUB_SUBJECT, client)

--- a/zulip-bot/src/notifier.py
+++ b/zulip-bot/src/notifier.py
@@ -5,20 +5,65 @@
 ###############################################################################
 
 
-STREAM_ID = "🧑‍💻 current batches" # channel (e.g. checkins)
-SUBJECT = "Virtual couches co-working" # topic (e.g. FirstName LastName)
+# NOTICE_STREAM_ID = "🧑‍💻 current batches" # channel (e.g. checkins)
+# NOTICE_SUBJECT = "Virtual couches co-working" # topic (e.g. FirstName LastName)
+
+# HUB_STREAM_ID = "397 Bridge"
+# HUB_SUBJECT = "RCTV Couches Telepresence"
+
+
+# TESTING FOR NOW
+NOTICE_STREAM_ID = "test-bot" 
+NOTICE_SUBJECT = "RC-couches-telepresence-bridge" 
+
+HUB_STREAM_ID = "test-bot"
+HUB_SUBJECT = "RC-couches-telepresence-bridge"
+
+
 ZOOM_LINK = "https://www.recurse.com/zoom/couches"
+COUCHES_ACTIVE_NOTICE = f"Couch bridge is active! Join the zoom call: {ZOOM_LINK}"
 
 
-def send_notification(client):
-    couches_active_notice = f"Couch bridge is active! Join the zoom call: {ZOOM_LINK}"
+def send_notification(notification_msg, stream_id, subject, client):
 
     # Send a channel message
     client.send_message({
         "type": "stream",
-        "to": STREAM_ID,
-        "topic": SUBJECT,
-        "content": couches_active_notice
+        "to": stream_id,
+        "topic": subject,
+        "content": notification_msg
     })
 
+
+def send_request_succeeded(mention_markdown, curr_stream_id, curr_subject, client):
+    hub_request_link = f"#**{HUB_STREAM_ID}>{HUB_SUBJECT}** "
+
+    REQUEST_SUCCEEDED = (
+        f"{mention_markdown} Great! Thanks for pinging me. "
+        f"I'll send a request to folks at the hub over in {hub_request_link}"
+    )
+
+    send_notification(REQUEST_SUCCEEDED, curr_stream_id, curr_subject, client)
+
+    # Prepare request to in-person hub folks (397 Bridge channel)
+    mention_topic = "@**topic**"
+    
+    REQUEST_TO_HUB = (
+        f"{mention_topic} Hey hub folks! "
+        "The remote RCers would like to open the couches bridge for telepresence. "
+        "Can you help them out? Activate the Zoom call on RCTV!"
+    )
+
+    send_notification(REQUEST_TO_HUB, HUB_STREAM_ID, HUB_SUBJECT, client)
+    
+
+def send_request_failed(mention_markdown, curr_stream_id, curr_subject, client):
+    REQUEST_FAILED = (
+        f"{mention_markdown} Sorry, I don't understand. "
+        "If you would like to request a bridge with the hub couches, say "
+        "\"Please open the portal\", or \"Please open the bridge\".\n\n"
+        "Don't forget to tag me!"
+    )
+
+    send_notification(REQUEST_FAILED, curr_stream_id, curr_subject, client)
 

--- a/zulip-bot/src/notifier.py
+++ b/zulip-bot/src/notifier.py
@@ -22,12 +22,16 @@ HUB_SUBJECT = "RCTV Couches Telepresence"
 
 HUB_REQUEST_LINK = f"#**{HUB_STREAM_ID}>{HUB_SUBJECT}** "
 
+VIRTUAL_TAG = "@**topic**"
 ZOOM_LINK = "https://www.recurse.com/zoom/couches"
-COUCHES_ACTIVE_NOTICE = f"Couch bridge is active! Join the zoom call: {ZOOM_LINK}"
+
+COUCHES_ACTIVE_NOTICE = (
+    f"{VIRTUAL_TAG} The couches bridge is **active**! " 
+    f"Join the Zoom call: {ZOOM_LINK}"
+)
 
 
 # Prepare request to in-person hub folks (397 Bridge channel)
-# MENTION_TAG = "@**topic**"
 MENTION_TAG = "@*Currently at the hub*"
 TESTING_SPOT = "#**test-bot>RC-couches-telepresence-bridge**"
 
@@ -76,6 +80,10 @@ def send_notification(notification_msg, stream_id, subject, client):
         "topic": subject,
         "content": notification_msg
     })
+
+
+def send_announcement(client):
+    send_notification(COUCHES_ACTIVE_NOTICE, NOTICE_STREAM_ID, NOTICE_SUBJECT, client)
 
 
 def send_request_succeeded(mention_markdown, curr_stream_id, curr_subject, client):

--- a/zulip-bot/src/notifier.py
+++ b/zulip-bot/src/notifier.py
@@ -27,11 +27,12 @@ COUCHES_ACTIVE_NOTICE = f"Couch bridge is active! Join the zoom call: {ZOOM_LINK
 
 
 # Prepare request to in-person hub folks (397 Bridge channel)
-MENTION_TOPIC = "@**topic**"
+# MENTION_TAG = "@**topic**"
+MENTION_TAG = "@*Currently at the hub*"
 TESTING_SPOT = "#**test-bot>RC-couches-telepresence-bridge**"
 
 REQUEST_TO_HUB = (
-    f"{MENTION_TOPIC} Hey hub folks! "
+    f"{MENTION_TAG} Hey hub folks! "
     "The remote RCers would like to open the couches bridge for telepresence. "
     "Can you help them out? Activate the Zoom call on RCTV!"
 

--- a/zulip-bot/src/setup.py
+++ b/zulip-bot/src/setup.py
@@ -22,4 +22,31 @@ def create_client():
     return zulip.Client(email=email, api_key=api_key)
 
 
+def subscribe_to_all_public_streams(client):
+    # Get all streams bot can see
+    streams_response = client.get_streams()
+    if streams_response["result"] != "success":
+        raise RuntimeError(f"Failed to fetch streams: {streams_response}")
+
+    # Get streams bot is already subscribed to
+    subs_response = client.get_subscriptions()
+    if subs_response["result"] != "success":
+        raise RuntimeError(f"Failed to fetch subscriptions: {subs_response}")
+
+    current_subs = {s["name"] for s in subs_response["subscriptions"]}
+
+    # Only include streams bot isn't already subscribed to
+    streams_to_subscribe = [
+        {"name": stream["name"]}
+        for stream in streams_response["streams"]
+        if stream["name"] not in current_subs
+    ]
+
+    if streams_to_subscribe:
+        add_resp = client.add_subscriptions(streams_to_subscribe)
+        if add_resp["result"] != "success":
+            raise RuntimeError(f"Failed to subscribe: {add_resp}")
+        return [s["name"] for s in streams_to_subscribe]
+
+    return []
 


### PR DESCRIPTION
- **Listening** 
  - Users can tag the bot using Zulip's mention markdown
  - Users can send the bot a DM
- **Responding**
  - If user request successful (valid):
    - Bot sends requester a confirmation message
    - Bot sends notification to 397 Bridge to alert hub folks
  - If user request unsuccessful (invalid):
    - Bot sends requester an error message with valid example
- **Flexibility**
  - Python Click to pass arguments via CLI
  - New Makefile rules for easy running
    - `make run-client` == one-off instance
      - AKA `python zulip-bot/bot.py --client`
      - Sends couches active announcement when Zoom launches
    - `make run-server` == 24/7 server
      - AKA `python zulip-bot/bot.py --server`
      - For running on heap cluster with Zulip messaging functionality 

<img width="878" height="661" alt="messaging demo" src="https://github.com/user-attachments/assets/e409888f-16bc-4872-8dfe-3ee5fa4cc166" />

<img width="878" height="184" alt="announcement demo" src="https://github.com/user-attachments/assets/495cd0ea-98fd-460d-94a4-475e7eba487e" />

<img width="852" height="39" alt="revised announcement" src="https://github.com/user-attachments/assets/28d35598-6dc2-44e6-ba84-1d0dcc1af9ff" />

