### PR TITLE
Set up bot on Heap Cluster as 24/7 service with Ansible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # RC Couches Telepresence Zulip Bot
 
+# Add Poetry's install location to PATH so Make can find it
+export PATH := $(HOME)/.local/bin:$(PATH)
+
 POETRY ?= poetry
 VENV_DIR = .venv
 PYTHON_VERSION = python3
-
-ACTIVATE_VENV = source $(VENV_DIR)/bin/activate &&
 
 .PHONY: setup run-launch run-close run-service clean format
 
@@ -22,15 +23,15 @@ setup:
 
 # Run bot client (launch) script as one-off instance
 run-launch:
-	@$(ACTIVATE_VENV) $(POETRY) run python zulip-bot/bot.py --launch
+	@$(POETRY) run python zulip-bot/bot.py --launch
 
 # Run bot client (close) script as one-off instance
 run-close:
-	@$(ACTIVATE_VENV) $(POETRY) run python zulip-bot/bot.py --close
+	@$(POETRY) run python zulip-bot/bot.py --close
 
 # Run bot service 24/7 to listen & respond 
 run-service:
-	@$(ACTIVATE_VENV) $(POETRY) run python zulip-bot/bot.py --service
+	@$(POETRY) run python zulip-bot/bot.py --service
 
 clean:
 	@echo "Removing virtual environment..."

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ POETRY ?= poetry
 VENV_DIR = .venv
 PYTHON_VERSION = python3
 
-.PHONY: setup run-launch run-close run-server clean 
+ACTIVATE_VENV = source $(VENV_DIR)/bin/activate &&
 
-all: setup run-server 
+.PHONY: setup run-launch run-close run-service clean format
+
+all: setup run-service 
 
 # Install Poetry dependencies & set up venv
 setup:
@@ -20,15 +22,15 @@ setup:
 
 # Run bot client (launch) script as one-off instance
 run-launch:
-	@$(POETRY) run python zulip-bot/bot.py --launch
+	@$(ACTIVATE_VENV) $(POETRY) run python zulip-bot/bot.py --launch
 
 # Run bot client (close) script as one-off instance
 run-close:
-	@$(POETRY) run python zulip-bot/bot.py --close
+	@$(ACTIVATE_VENV) $(POETRY) run python zulip-bot/bot.py --close
 
-# Run bot server 24/7 to listen & respond 
-run-server:
-	@$(POETRY) run python zulip-bot/bot.py --server
+# Run bot service 24/7 to listen & respond 
+run-service:
+	@$(ACTIVATE_VENV) $(POETRY) run python zulip-bot/bot.py --service
 
 clean:
 	@echo "Removing virtual environment..."

--- a/README.md
+++ b/README.md
@@ -65,26 +65,28 @@ To **end** the Zoom session:
 
 **`Couches Bridge Bot` runs 24/7 on [RC's Heap Community Cluster](https://www.recurse.com/blog/126-heap-sponsors-rc-community-cluster).** This service functionality is what enables folks in the RC community to engage with the bot via Zulip messaging. 
 
-### Heap cluster for bot admins:
+### Overview notes:
 
-These commands are designed for project collaborators, i.e. folks who are responsible for maintaining the bot. They have been granted explicit permission on the Heap Cluster that authorizes them to perform these actions. All steps below assume that the user has already SSH'ed into the relevant cluster machine with valid credentials. 
+These commands are designed for project collaborators, i.e. folks responsible for **maintaining the bot**. They have been granted explicit permission on the Heap Cluster, which authorizes them to perform these actions. All steps below assume that the user has already **SSH'ed into the relevant cluster machine** with valid credentials. 
 
-Run new bash shell (switch to bot service user):
+### Heap for bot admins:
+
+Run **new bash shell** (switch to bot service user):
 ```
 sudo -u svc-couches-telepresence-bot bash
 ```
 
-Point to bot service user environment (view from there):
+Point to bot **service user environment** (view from there):
 ```
 export XDG_RUNTIME_DIR="/run/user/$(id -u)"
 ```
 
-Check bot service status:
+Check bot **service status**:
 ```
 systemctl --user status couches-telepresence.service
 ```
 
-Review any bot service logs:
+Review any bot **service logs**:
 ```
 journalctl --user -u couches-telepresence.service
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ To **end** the Zoom session:
 ```
 
 
+## RC Heap Cluster
+
+**`Couches Bridge Bot` runs 24/7 on [RC's Heap Community Cluster](https://www.recurse.com/blog/126-heap-sponsors-rc-community-cluster).** This service functionality is what enables folks in the RC community to engage with the bot via Zulip messaging. 
+
+### Heap cluster for bot admins:
+
+These commands are designed for project collaborators, i.e. folks who are responsible for maintaining the bot. They have been granted explicit permission on the Heap Cluster that authorizes them to perform these actions. All steps below assume that the user has already SSH'ed into the relevant cluster machine with valid credentials. 
+
+Run new bash shell (switch to bot service user):
+```
+sudo -u svc-couches-telepresence-bot bash
+```
+
+Point to bot service user environment (view from there):
+```
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+```
+
+Check bot service status:
+```
+systemctl --user status couches-telepresence.service
+```
+
+Review any bot service logs:
+```
+journalctl --user -u couches-telepresence.service
+```
+
+
 ## To Do:
 
 - rebuild scripts to launch without needing the command line (i.e., bring profile in), and not maximize not based on timing

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To run bot as a **client** (`close` mode: one-off, when Zoom call ends):
 make run-close
 ```
 
-To run bot as a **server** (listen for and respond to messages 24/7):
+To run bot as a **service** (listen for and respond to messages 24/7):
 ```
-make run-server
+make run-service
 ```
 
 ### For the backend:
@@ -65,6 +65,6 @@ To **end** the Zoom session:
 
 - rebuild scripts to launch without needing the command line (i.e., bring profile in), and not maximize not based on timing
 - add the RCTV script to launch on zoom kill
-- set up laptop so recurse account does not need sudo, and turn off sleep so it's functionally a server with a gui
+- set up laptop so recurse account does not need sudo, and turn off sleep so it's functionally a service with a gui
 
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,23 @@ To **end** the Zoom session:
 
 ### Overview notes:
 
-These commands are designed for project collaborators, i.e. folks responsible for **maintaining the bot**. They have been granted explicit permission on the Heap Cluster, which authorizes them to perform these actions. All steps below assume that the user has already **SSH'ed into the relevant cluster machine** with valid credentials. 
+These commands are designed for **project collaborators**, i.e. folks responsible for **maintaining the bot**. They have been granted explicit permission on the Heap Cluster, which authorizes them to perform these actions. All steps below assume that the user has already **SSH'ed into the relevant cluster machine** with valid credentials. 
 
-### Heap for bot admins:
+For more information, reach out to [Adrien Lynch](https://github.com/aadriien) or [Florian Ragwitz](https://github.com/rafl). 
+
+### Heap deployment:
+
+Install **Ansible** (if needed):
+```
+brew install ansible
+```
+
+**Deploy `Couches Bridge Bot`** via Ansible:
+```
+ansible-playbook -i ansible/inventory ansible/deploy.yml
+```
+
+### Heap maintenance:
 
 Run **new bash shell** (switch to bot service user):
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This tool aims to bridge the **in-person couches** at the RC hub with the **remo
 
 This project was collaboratively created by [Dave Long](https://github.com/demaere-oiie), [Adrien Lynch](https://github.com/aadriien), [Matt Megaard](https://github.com/mmegaard), and [Sharon Sung](https://github.com/minsun-ss) during the Fall 2 (Sept 2025) Pairing Jam event at [the Recurse Center](https://www.recurse.com)! 
 
+Thank you to [Florian Ragwitz](https://github.com/rafl) for helping with bot setup (24/7 service) on the Heap Cluster!
+
 
 ## How It Works
 

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -10,8 +10,8 @@
     - block:
       - include_role:
           name: code
-      # - include_role:
-      #     name: svc
+      - include_role:
+          name: svc
       environment:
         DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ svc_uid.stdout }}/bus"
       vars:

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,0 +1,18 @@
+- hosts: all
+  become: true
+  become_user: svc-couches-telepresence-bot
+  pre_tasks:
+    - command: id -u
+      register: svc_uid
+    - shell: "echo $HOME"
+      register: home_res
+  tasks:
+    - block:
+      - include_role:
+          name: code
+      # - include_role:
+      #     name: svc
+      environment:
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ svc_uid.stdout }}/bus"
+      vars:
+        home: "{{ home_res.stdout }}"

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,0 +1,1 @@
+broome.cluster.recurse.com

--- a/ansible/roles/code/tasks/main.yml
+++ b/ansible/roles/code/tasks/main.yml
@@ -17,6 +17,7 @@
     - zulip-bot/src/notifier.py
     - zulip-bot/src/setup.py
     - zulip-bot/src/status.py
+    - Makefile
     - poetry.lock
     - pyproject.toml
     - .env

--- a/ansible/roles/code/tasks/main.yml
+++ b/ansible/roles/code/tasks/main.yml
@@ -1,0 +1,19 @@
+- file:
+    path: "{{ tgt }}"
+    state: directory
+
+- copy:
+    src: "{{ repo }}/{{ item }}"
+    dest: "{{ tgt }}/{{ item }}"
+    mode: 0600
+  with_items:
+    - zulip-bot/bot.py
+    - zulip-bot/src/bridge.py
+    - zulip-bot/src/constants.py
+    - zulip-bot/src/notifier.py
+    - zulip-bot/src/setup.py
+    - zulip-bot/src/status.py
+    - poetry.lock
+    - pyproject.toml
+    - .env
+

--- a/ansible/roles/code/tasks/main.yml
+++ b/ansible/roles/code/tasks/main.yml
@@ -1,6 +1,10 @@
 - file:
-    path: "{{ tgt }}"
+    path: "{{ tgt }}/{{ item }}"
     state: directory
+  with_items:
+    - ""
+    - zulip-bot
+    - zulip-bot/src
 
 - copy:
     src: "{{ repo }}/{{ item }}"

--- a/ansible/roles/code/vars/main.yml
+++ b/ansible/roles/code/vars/main.yml
@@ -1,0 +1,2 @@
+tgt: /home/svc-couches-telepresence-bot/couches-telepresence-bot
+repo: ..

--- a/ansible/roles/svc/tasks/main.yml
+++ b/ansible/roles/svc/tasks/main.yml
@@ -1,0 +1,23 @@
+- file:
+    path: "{{ home }}/.config/systemd/user"
+    state: directory
+    mode: "0755"
+
+- copy:
+    dest: "{{ home }}/.config/systemd/user/couches-telepresence.service"
+    content: |
+      [Unit]
+      Description=couches-telepresence (service)
+      [Service]
+      Restart=on-failure
+      WorkingDirectory={{ home }}/couches-telepresence
+      ExecStart=make run-service
+      [Install]
+      WantedBy=default.target
+
+- systemd:
+    name: "couches-telepresence.service"
+    scope: user
+    enabled: true
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/svc/tasks/main.yml
+++ b/ansible/roles/svc/tasks/main.yml
@@ -10,8 +10,8 @@
       Description=couches-telepresence (service)
       [Service]
       Restart=on-failure
-      WorkingDirectory={{ home }}/couches-telepresence
-      ExecStart=make run-service
+      WorkingDirectory={{ home }}/couches-telepresence-bot
+      ExecStart=make all
       [Install]
       WantedBy=default.target
 

--- a/zulip-bot/bot.py
+++ b/zulip-bot/bot.py
@@ -32,12 +32,12 @@ bot = CouchesBridgeBot()
 @click.command()
 @click.option("--launch", is_flag=True, help="Run in client mode (launch)")
 @click.option("--close", is_flag=True, help="Run in client mode (close)")
-@click.option("--server", is_flag=True, help="Run in server mode")
-def launch_program(launch, close, server):
+@click.option("--service", is_flag=True, help="Run in service mode")
+def launch_program(launch, close, service):
     # Ensure only 1 mode specified
-    flags = [launch, close, server]
+    flags = [launch, close, service]
     if sum(flags) != 1:
-        raise click.UsageError("ERROR: You must provide exactly one of --launch, --close, or --server")
+        raise click.UsageError("ERROR: You must provide exactly one of --launch, --close, or --service")
 
     # Bot acts as a one-off script (launch or close) to send announcement for bridge status
     if launch or close:
@@ -45,13 +45,13 @@ def launch_program(launch, close, server):
         click.echo(f"Running in client ({mode}) mode...")
         send_announcement(bot.client, mode)
 
-    # Bot acts as a server running 24/7 to listen for & respond to messages
-    elif server:
-        click.echo("Running in server mode...")
+    # Bot acts as a service running 24/7 to listen for & respond to messages
+    elif service:
+        click.echo("Running in service mode...")
         bot.run()
 
     else:
-        raise click.UsageError("ERROR: Please specify --launch or --close or --server")
+        raise click.UsageError("ERROR: Please specify --launch or --close or --service")
 
 
 if __name__ == "__main__":
@@ -61,10 +61,10 @@ if __name__ == "__main__":
     #   can use Python Click to pass CLI arguments
     # For example,
     #   `python3 bot.py --client`
-    #   `python3 bot.py --server`
+    #   `python3 bot.py --service`
     # Or alternativey, just use Makefile rules
     #   `make run-client`
-    #   `make run-server`
+    #   `make run-service`
 
     launch_program()
 


### PR DESCRIPTION
### Things changed:
- Adjusted Makefile rules to reflect bot's identity as a service, not a server
  - Also updated README documentation 
  - Also updated `bot.py` Click args
    - Switch `--server` to `--service`
- Fixed tiny bug in Makefile with Poetry installation / setup
  - Ensures path accessible on Heap Cluster

### Things added:
- Ansible directory (`ansible`)
  - Logic for Heap Cluster deployment
  - Service account for bot
- New README section for RC's Heap Cluster 
  - Overview documentation
  - Steps for deployment
  - Commands for status checks
  